### PR TITLE
[Mozilla Branding Removal] Update package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       "peerDependencies": {
         "bitecs": "github:Hubs-Foundation/bitECS#hubs-patches",
         "postprocessing": "~6.28.7",
-        "three": "github:mozillareality/three.js#65b5105908f5f135cad25fed07e25f15f3876777"
+        "three": "github:Hubs-Foundation/three.js#65b5105908f5f135cad25fed07e25f15f3876777"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -2333,7 +2333,7 @@
     },
     "bitecs": {
       "version": "git+ssh://git@github.com/Hubs-Foundation/bitECS.git#913b4ae261684eee205251e41a3250d1c1a2817e",
-      "from": "bitecs@github:mozilla/bitECS#hubs-patches"
+      "from": "bitecs@github:Hubs-Foundation/bitECS#hubs-patches"
     },
     "braces": {
       "version": "3.0.2",
@@ -3110,7 +3110,7 @@
     "three": {
       "version": "git+ssh://git@github.com/Hubs-Foundation/three.js.git#65b5105908f5f135cad25fed07e25f15f3876777",
       "integrity": "sha512-J6jMBkLHP+YqHHEHsn5iFBTbrhzw8yrO4ZqD0gQM3RrchgG0h6ZZp3XW90IwvrNqRDI2YBTys50d3JsPF5pJEg==",
-      "from": "three@github:mozillareality/three.js#65b5105908f5f135cad25fed07e25f15f3876777",
+      "from": "three@github:Hubs-Foundation/three.js#65b5105908f5f135cad25fed07e25f15f3876777",
       "peer": true
     },
     "to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "type": "module",
   "module": "dist/index.mjs",
   "devDependencies": {
-    "@types/hubs": "github:MozillaReality/hubs-ts-types#main",
+    "@types/hubs": "github:Hubs-Foundation/hubs-ts-types#main",
     "@types/node": "^18.15.0",
     "@types/three": "^0.141.0",
     "ts-loader": "^9.5.1",
@@ -35,8 +35,8 @@
     "webpack-cli": "^5.1.4"
   },
   "peerDependencies": {
-    "bitecs": "github:mozilla/bitECS#hubs-patches",
+    "bitecs": "github:Hubs-Foundation/bitECS#hubs-patches",
     "postprocessing": "~6.28.7",
-    "three": "github:mozillareality/three.js#65b5105908f5f135cad25fed07e25f15f3876777"
+    "three": "github:Hubs-Foundation/three.js#65b5105908f5f135cad25fed07e25f15f3876777"
   }
 }


### PR DESCRIPTION
Update the links to reflect the change to Hubs Foundation.
Update a few missed links in package-lock.json as well.
Now that both package.json and package-lock.json are back in sync npm ci completes successfully again.

Relates to PR #2